### PR TITLE
Adding support wifi USB dongle from comfast

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -322,6 +322,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x0411, 0x0242),.driver_info = RTL8821}, /* BUFFALO - Edimax */
 	{USB_DEVICE(0x0411, 0x025D),.driver_info = RTL8821}, /* BUFFALO - WI-U3-866D */
 	{USB_DEVICE(0x056E, 0x4007),.driver_info = RTL8821}, /* ELECOM - WDC-433DU2H */
+	{USB_DEVICE(0x0BDA, 0xa811),.driver_info = RTL8821}, /* Comcast - CF-915AC */	
 #endif
 
 #ifdef CONFIG_RTL8192E


### PR DESCRIPTION
Vendor Homepage specifications / driver: [Comfast CF-915AC]( http://en.comfast.com.cn/product/item-226.html) 
```
lsusb
Bus 001 Device 010: ID 0bda:a811 Realtek Semiconductor Corp.
```
Might also support detection of [Logilink 802.11ac Nano USB Adapter WL0237]( https://ubuntuforums.org/showthread.php?t=2327495)